### PR TITLE
Implement theming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,31 @@ npm run build
 
 The compiled files will be emitted to the `dist` directory and can be
 published to npm using `npm publish`.
+
+## Theming
+
+The library exposes a set of CSS variables defined in `src/index.css`. Each
+theme provides values for these variables using the `@theme` directive. By
+default the variables are defined on `:root`, but additional blocks such as
+`.dark`, `.brand-a` and `.brand-b` override them.
+
+To apply a theme, add the desired class to the root element of your
+application:
+
+```html
+<body class="brand-a">
+  <div id="root"></div>
+</body>
+```
+
+Consumers can also extend the theme by providing their own class and setting the
+variables they wish to override.
+
+```css
+.my-brand {
+  --color-primary: #ff9900;
+  --color-primary-hover: #cc7a00;
+}
+```
+
+Import your custom CSS after the library styles to take precedence.

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -15,3 +15,25 @@ export const Primary: Story = {
     children: 'Button',
   },
 }
+
+export const Dark: Story = {
+  render: (args) => (
+    <div className="dark p-4">
+      <Button {...args} />
+    </div>
+  ),
+  args: {
+    children: 'Button',
+  },
+}
+
+export const BrandA: Story = {
+  render: (args) => (
+    <div className="brand-a p-4">
+      <Button {...args} />
+    </div>
+  ),
+  args: {
+    children: 'Button',
+  },
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,17 +9,18 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ asChild = false, className, ...props }, ref) => {
     const Comp: any = asChild ? Slot : 'button'
-    return (
-      <Comp
-        ref={ref}
-        className={clsx(
-          'inline-flex items-center justify-center rounded px-4 py-2 text-sm font-medium transition-colors',
-          'bg-black text-white hover:bg-gray-800 disabled:opacity-50',
-          className,
-        )}
-        {...props}
-      />
-    )
+      return (
+        <Comp
+          ref={ref}
+          className={clsx(
+            'inline-flex items-center justify-center px-4 py-2 text-sm font-medium transition-colors',
+            'bg-[var(--color-primary)] text-[var(--color-on-primary)] hover:bg-[var(--color-primary-hover)] disabled:opacity-50',
+            'rounded-[var(--radius-md)]',
+            className,
+          )}
+          {...props}
+        />
+      )
   },
 )
 Button.displayName = 'Button'

--- a/src/index.css
+++ b/src/index.css
@@ -2,12 +2,34 @@
 
 @theme {
   --color-primary: var(--color-primary);
+  --color-primary-hover: var(--color-primary-hover);
+  --color-on-primary: var(--color-on-primary);
+  --radius-md: var(--radius-md);
+  --border-color: var(--border-color);
 }
 
 :root {
-  --color-primary: #000000;
+  --color-primary: #1d4ed8;
+  --color-primary-hover: #1e40af;
+  --color-on-primary: #ffffff;
+  --radius-md: 0.375rem;
+  --border-color: #e5e7eb;
 }
 
 .dark {
-  --color-primary: #ffffff;
+  --color-primary: #f3f4f6;
+  --color-primary-hover: #d1d5db;
+  --color-on-primary: #1f2937;
+}
+
+.brand-a {
+  --color-primary: #e11d48;
+  --color-primary-hover: #be123c;
+  --color-on-primary: #ffffff;
+}
+
+.brand-b {
+  --color-primary: #10b981;
+  --color-primary-hover: #059669;
+  --color-on-primary: #ffffff;
 }


### PR DESCRIPTION
## Summary
- define CSS variables for theme tokens and create `dark`, `brand-a` and `brand-b` theme blocks
- update `Button` component styles to consume variables
- add Storybook stories showing dark and brand themes
- document how to enable or extend themes in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_68412b0c64c88332bee319c5d5cc8cd3