### PR TITLE
Add CVA-based button variants

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,20 +1,38 @@
-import type { Meta, StoryObj } from '@storybook/react'
-import { Button } from './Button'
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "./Button";
 
 const meta = {
-  title: 'Components/Button',
+  title: "Components/Button",
   component: Button,
-  tags: ['autodocs'],
-} satisfies Meta<typeof Button>
+  tags: ["autodocs"],
+} satisfies Meta<typeof Button>;
 
-export default meta
-export type Story = StoryObj<typeof meta>
+export default meta;
+export type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
-    children: 'Button',
+    children: "Button",
+    variant: "primary",
+    size: "medium",
   },
-}
+};
+
+export const Secondary: Story = {
+  args: {
+    children: "Button",
+    variant: "secondary",
+    size: "medium",
+  },
+};
+
+export const GShop: Story = {
+  args: {
+    children: "Button",
+    variant: "gshop",
+    size: "medium",
+  },
+};
 
 export const Dark: Story = {
   render: (args) => (
@@ -23,9 +41,9 @@ export const Dark: Story = {
     </div>
   ),
   args: {
-    children: 'Button',
+    children: "Button",
   },
-}
+};
 
 export const BrandA: Story = {
   render: (args) => (
@@ -34,6 +52,6 @@ export const BrandA: Story = {
     </div>
   ),
   args: {
-    children: 'Button',
+    children: "Button",
   },
-}
+};

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,27 +1,53 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import clsx from "clsx";
+import { cva, type VariantProps } from "../lib/cva";
+
+const buttonStyles = cva(
+  "inline-flex items-center justify-center rounded-md font-medium transition-colors disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        primary:
+          "bg-brand-foreground-1-rest text-neutral-fg-1-rest hover:bg-brand-foreground-1-pressed text-white",
+        secondary:
+          "bg-neutral-bg-2-rest text-neutral-foreground-1 hover:bg-neutral-bg-2-pressed border border-neutral-stroke-1-rest",
+        gshop: "bg-green-600 text-white hover:bg-green-700",
+      },
+      size: {
+        tiny: "px-2 py-1 text-xs",
+        small: "px-3 py-1.5 text-button-small",
+        medium: "px-4 py-2 text-button-medium",
+        large: "px-6 py-3 text-button-large",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "medium",
+    },
+  },
+);
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonStyles> {
   asChild?: boolean;
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ asChild = false, className, ...props }, ref) => {
+  (
+    { asChild = false, variant, size, className, ...props },
+    ref,
+  ) => {
     const Comp: any = asChild ? Slot : "button";
+
     return (
       <Comp
         ref={ref}
-        className={clsx(
-          "inline-flex items-center justify-center px-4 py-2 text-button-small font-medium transition-colors",
-          "bg-brand-foreground-1-rest text-neutral-fg-1-rest hover:bg-brand-foreground-1-pressed disabled:opacity-50",
-          "rounded-md text-white",
-          className
-        )}
+        className={clsx(buttonStyles({ variant, size, className }))}
         {...props}
       />
     );
-  }
+  },
 );
 Button.displayName = "Button";

--- a/src/lib/cva.ts
+++ b/src/lib/cva.ts
@@ -1,0 +1,42 @@
+import clsx, { type ClassValue } from "clsx";
+
+export function cn(...inputs: ClassValue[]) {
+  return clsx(inputs);
+}
+
+type Variants = Record<string, Record<string, string>>;
+
+interface CvaOptions<V extends Variants> {
+  variants?: V;
+  defaultVariants?: { [K in keyof V]?: keyof V[K] };
+}
+
+export type VariantProps<T extends (...args: any) => string> = T extends (
+  options: infer O,
+) => any
+  ? O extends { className?: string }
+    ? Omit<O, "className">
+    : never
+  : never;
+
+export function cva<V extends Variants>(
+  base?: string,
+  options?: CvaOptions<V>,
+) {
+  return (
+    props?: Partial<{ [K in keyof V]: keyof V[K] }> & { className?: string },
+  ) => {
+    const { variants = {} as V, defaultVariants } = options || {};
+    const classNames: ClassValue[] = [base];
+
+    for (const key in variants) {
+      const val = props?.[key] ?? defaultVariants?.[key];
+      if (val && variants[key][val]) {
+        classNames.push(variants[key][val]);
+      }
+    }
+
+    if (props?.className) classNames.push(props.className);
+    return cn(...classNames);
+  };
+}


### PR DESCRIPTION
## Summary
- implement a minimal `cva` utility to manage class variants
- refactor `Button` to use `cva` for `variant` and `size` options

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841361ce22c83328816939237eb3e90